### PR TITLE
Fixed a bug related to the configuration file reading.

### DIFF
--- a/lib/configuration_reader.js
+++ b/lib/configuration_reader.js
@@ -231,7 +231,7 @@ function parseLogger2(logger, node, appenders) {
 
 
 function doRead() {
-    var configFile = process.env.BLAMMO_CONFIG || 'blammo.xml';
+    var configFile = __dirname + '/../' + (process.env.BLAMMO_CONFIG || 'blammo.xml');
     if (fs.existsSync && fs.existsSync(configFile)) {
         readConfiguration(configFile);
     } else if (path.existsSync(configFile)) { // for Node 0.6

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "blammo",
     "description": "Blammo! Logger for NodeJS - built after LogBack for Java",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "author": "Steven Looman <steven.looman@gmail.com>",
     "keywords": [ "logger", "logging", "log", "blammo" ],
     "licenses" : [


### PR DESCRIPTION
This commit fixes a bug that appeared when including a project that itself depends on Blammo. The blammo.xml file was always looked up in './blammo.xml', regardless of the real directory tree and where Blammo was used. Using the  __directory variable fixes this behavior.

Example:

```
my_project
    └── some_project_that_uses_blammo
        ├── lib
        ├── node_modules
        │   ├── blammo
        ├── blammo.xml
```

In this example, blammo.xml wasn't found (as the code referred to './', which was 'my_project/').
