### PR TITLE
Really disable blammo if no configuration is specified

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -168,6 +168,10 @@ Logger.prototype.error = function() {
  * Substitute the given method by a function which logs the entry and then calls the original method
  */
 Logger.traceEntry = function(logger, obj, func_name) {
+    if (this.getLevel() > level) {
+        return;
+    }
+
     var subbed_func_name = '__pre__' + func_name;
     var obj_name = obj.constructor.toString().match(/function (\w+)/)[1];
 
@@ -189,6 +193,10 @@ Logger.traceEntry = function(logger, obj, func_name) {
  * Substitute the given method by a function which calls the original method and then logs the exit
  */
 Logger.traceExit = function(logger, obj, func_name) {
+    if (this.getLevel() > level) {
+        return;
+    }
+
     var subbed_func_name = '__post__' + func_name;
     var obj_name = obj.constructor.toString().match(/function (\w+)/)[1];
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -172,13 +172,6 @@ Logger.traceEntry = function(logger, obj, func_name) {
     var obj_name = obj.constructor.toString().match(/function (\w+)/)[1];
 
     utils.substitute(obj, func_name, subbed_func_name, function() {
-        var result;
-
-        if (logger.getLevel() > Levels.TRACE) {
-            result = this[subbed_func_name].apply(this, arguments);
-            return result;
-        }
-
         var message = '--> ' + obj_name + '.' + func_name + '(' + Array.prototype.slice.call(arguments).join(', ') + ')';
         if (Logger.autoIndentTrace) {
             message = indent(Logger.__autoIndentLevel) + message;
@@ -186,7 +179,7 @@ Logger.traceEntry = function(logger, obj, func_name) {
         logger.trace(message);
         Logger.__autoIndentLevel += 1;
 
-        result = this[subbed_func_name].apply(this, arguments);
+        var result = this[subbed_func_name].apply(this, arguments);
         return result;
     });
 };
@@ -201,10 +194,6 @@ Logger.traceExit = function(logger, obj, func_name) {
 
     utils.substitute(obj, func_name, subbed_func_name, function() {
         var result = this[subbed_func_name].apply(this, arguments);
-
-        if (logger.getLevel() > Levels.TRACE) {
-            return result;
-        }
 
         Logger.__autoIndentLevel -= 1;
         var message = '<-- ' + obj_name + '.' + func_name + '(' + Array.prototype.slice.call(arguments).join(', ') + ')';

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -168,7 +168,7 @@ Logger.prototype.error = function() {
  * Substitute the given method by a function which logs the entry and then calls the original method
  */
 Logger.traceEntry = function(logger, obj, func_name) {
-    if (this.getLevel() > level) {
+    if (logger.getLevel() > Levels.TRACE) {
         return;
     }
 
@@ -193,7 +193,7 @@ Logger.traceEntry = function(logger, obj, func_name) {
  * Substitute the given method by a function which calls the original method and then logs the exit
  */
 Logger.traceExit = function(logger, obj, func_name) {
-    if (this.getLevel() > level) {
+    if (logger.getLevel() > Levels.TRACE) {
         return;
     }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -35,7 +35,7 @@ Logger.prototype.getLevel = function() {
         return this.parent.getLevel();
     }
 
-    return this.level;
+    return (this.level === undefined) ? Levels.OFF : this.level;
 };
 
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -168,14 +168,17 @@ Logger.prototype.error = function() {
  * Substitute the given method by a function which logs the entry and then calls the original method
  */
 Logger.traceEntry = function(logger, obj, func_name) {
-    if (logger.getLevel() > Levels.TRACE) {
-        return;
-    }
-
     var subbed_func_name = '__pre__' + func_name;
     var obj_name = obj.constructor.toString().match(/function (\w+)/)[1];
 
     utils.substitute(obj, func_name, subbed_func_name, function() {
+        var result;
+
+        if (logger.getLevel() > Levels.TRACE) {
+            result = this[subbed_func_name].apply(this, arguments);
+            return result;
+        }
+
         var message = '--> ' + obj_name + '.' + func_name + '(' + Array.prototype.slice.call(arguments).join(', ') + ')';
         if (Logger.autoIndentTrace) {
             message = indent(Logger.__autoIndentLevel) + message;
@@ -183,7 +186,7 @@ Logger.traceEntry = function(logger, obj, func_name) {
         logger.trace(message);
         Logger.__autoIndentLevel += 1;
 
-        var result = this[subbed_func_name].apply(this, arguments);
+        result = this[subbed_func_name].apply(this, arguments);
         return result;
     });
 };
@@ -193,15 +196,15 @@ Logger.traceEntry = function(logger, obj, func_name) {
  * Substitute the given method by a function which calls the original method and then logs the exit
  */
 Logger.traceExit = function(logger, obj, func_name) {
-    if (logger.getLevel() > Levels.TRACE) {
-        return;
-    }
-
     var subbed_func_name = '__post__' + func_name;
     var obj_name = obj.constructor.toString().match(/function (\w+)/)[1];
 
     utils.substitute(obj, func_name, subbed_func_name, function() {
         var result = this[subbed_func_name].apply(this, arguments);
+
+        if (logger.getLevel() > Levels.TRACE) {
+            return result;
+        }
 
         Logger.__autoIndentLevel -= 1;
         var message = '<-- ' + obj_name + '.' + func_name + '(' + Array.prototype.slice.call(arguments).join(', ') + ')';


### PR DESCRIPTION
This Pull Request modifies Logger's behavior:
- it makes Logger.level() return Levels.OFF if no level is set. Previously, this returned undefined.
- it disables Logger.traceEntry() and Logger.traceExit() if Logger.level() < Levels.TRACE.

Together, these two commits make sure that no log will take place if blammo isn't configured, thus not impacting the application's performance.

Here is my specific use case : I have an application that uses SaXPath, which itself uses blammo. I don't want any blammo logging operation to occur, as it really slows down my application.
